### PR TITLE
fix: `attempt to index a nil value (field 'options')`

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1318,10 +1318,11 @@ AddEventHandler("pmms:start", function(handle, options)
 	})
 end)
 
-AddEventHandler("pmms:play", function(handle)
-	sendMediaMessage(handle, nil, {
+AddEventHandler("pmms:play", function(handle, options)
+	sendMediaMessage(handle, options.coords, {
 		type = "play",
-		handle = handle
+		handle = handle,
+		options = options
 	})
 end)
 

--- a/server.lua
+++ b/server.lua
@@ -117,7 +117,7 @@ local function addMediaPlayer(handle, options)
 	mediaPlayers[handle] = options
 
 	enqueue(syncQueue, function()
-		TriggerClientEvent("pmms:play", -1, handle)
+		TriggerClientEvent("pmms:play", -1, handle, options)
 	end)
 end
 


### PR DESCRIPTION
This PR resolves issue: #71

![image](https://github.com/kibook/pmms/assets/54480523/b7377c93-1cf3-456d-915e-a447d61a941e)

## Recreation

You can recreate this error by running the following code on your server-side:

```lua
local src = source
local ped = GetPlayerPed(src)

if ped then
	exports.pmms:startByNetworkId(NetworkGetNetworkIdFromEntity(ped), {
		url = "SOME URL",
		duration = 3,
		range = 5
	})
end
```

## Solution

This is solved via actually passing down the options to the `pmms:play` event and `sendMediaMessage` function.